### PR TITLE
Simplification of container.getOptions

### DIFF
--- a/packages/desktopjs-electron/src/electron.ts
+++ b/packages/desktopjs-electron/src/electron.ts
@@ -7,7 +7,7 @@ import {
     registerContainer, ContainerWindow, PersistedWindowLayout, Rectangle, Container, WebContainerBase,
     ScreenManager, Display, Point, ObjectTransform, PropertyMap, NotificationOptions, ContainerNotification,
     TrayIconDetails, MenuItem, Guid, MessageBus, MessageBusSubscription, MessageBusOptions, GlobalShortcutManager,
-    EventArgs, WindowEventArgs, IContainerOptions
+    EventArgs, WindowEventArgs
 } from "@morgan-stanley/desktopjs";
 
 registerContainer("Electron", {
@@ -386,7 +386,7 @@ export class ElectronContainer extends WebContainerBase {
             }
 
             if (options && options.autoStartOnLogin) {
-                this.electron.setLoginItemSettings({
+                this.app.setLoginItemSettings({
                     openAtLogin: options.autoStartOnLogin
                 });
             }
@@ -409,10 +409,9 @@ export class ElectronContainer extends WebContainerBase {
         }
     }
 
-    public async getOptions(): Promise<IContainerOptions> {
+    public async getOptions(): Promise<any> {
         try {
-            const autoStartOnLogin = await this.isAutoStartEnabledAtLogin();
-            return { autoStartOnLogin };
+            return { autoStartOnLogin: await this.isAutoStartEnabledAtLogin() };
         } catch(error) {
             throw new Error("Error getting Container options. " + error);
         }
@@ -421,7 +420,7 @@ export class ElectronContainer extends WebContainerBase {
     private isAutoStartEnabledAtLogin(): Promise<boolean> {
         return new Promise<boolean>((resolve, reject) => {
             try {
-                const config = this.electron.getLoginItemSettings();
+                const config = this.app.getLoginItemSettings();
                 resolve(config.openAtLogin);
             } catch (err) {
                 reject(err);

--- a/packages/desktopjs-openfin/src/openfin.ts
+++ b/packages/desktopjs-openfin/src/openfin.ts
@@ -6,7 +6,7 @@ import {
     registerContainer, ContainerWindow, PersistedWindowLayout, Rectangle, Container, WebContainerBase,
     ScreenManager, Display, Point, ObjectTransform, PropertyMap, NotificationOptions, ContainerNotification,
     TrayIconDetails, MenuItem, Guid, MessageBus, MessageBusSubscription, MessageBusOptions, EventArgs,
-    GlobalShortcutManager, WindowEventArgs, IContainerOptions
+    GlobalShortcutManager, WindowEventArgs
 } from "@morgan-stanley/desktopjs";
 
 registerContainer("OpenFin", {
@@ -444,10 +444,9 @@ export class OpenFinContainer extends WebContainerBase {
         }
     }
 
-    public async getOptions(): Promise<IContainerOptions> {
+    public async getOptions(): Promise<any> {
         try {
-            const autoStartOnLogin = await this.isAutoStartEnabledAtLogin();
-            return { autoStartOnLogin };
+            return { autoStartOnLogin: await this.isAutoStartEnabledAtLogin() };
         } catch(error) {
             throw new Error("Error getting Container options. " + error);
         }

--- a/packages/desktopjs-openfin/tests/openfin.spec.ts
+++ b/packages/desktopjs-openfin/tests/openfin.spec.ts
@@ -1,6 +1,6 @@
 import {} from "jasmine";
 import { OpenFinContainer, OpenFinContainerWindow, OpenFinMessageBus } from "../src/openfin";
-import { ContainerWindow, MessageBusSubscription, MenuItem, IContainerOptions } from "@morgan-stanley/desktopjs";
+import { ContainerWindow, MessageBusSubscription, MenuItem } from "@morgan-stanley/desktopjs";
 
 class MockDesktop {
     public static application: any = {
@@ -770,7 +770,7 @@ describe("OpenFinContainer", () => {
             const current = app.getCurrent();
             spyOn(app, "getCurrent").and.callThrough();
             spyOn(current, "getShortcuts").and.callFake((callback) => callback({ systemStartup: true }));
-            container.getOptions().then((result: IContainerOptions) => {
+            container.getOptions().then((result: any) => {
                 expect(app.getCurrent).toHaveBeenCalled();
                 expect(current.getShortcuts).toHaveBeenCalled();
                 expect(result.autoStartOnLogin).toEqual(true);

--- a/packages/desktopjs/src/desktop.ts
+++ b/packages/desktopjs/src/desktop.ts
@@ -15,6 +15,5 @@ export * from "./tray";
 export * from "./window";
 export * from "./shortcut";
 export * from "./Default/default";
-export * from "./i-container-options";
 
 export const version = "PACKAGE_VERSION";

--- a/packages/desktopjs/src/i-container-options.ts
+++ b/packages/desktopjs/src/i-container-options.ts
@@ -1,3 +1,0 @@
-export interface IContainerOptions {
-    autoStartOnLogin?: boolean;
-}

--- a/packages/desktopjs/tests/unit/container.spec.ts
+++ b/packages/desktopjs/tests/unit/container.spec.ts
@@ -4,7 +4,6 @@ import { ContainerWindow, PersistedWindowLayout } from "../../src/window";
 import { NotificationOptions } from "../../src/notification";
 import { MessageBus, MessageBusSubscription, MessageBusOptions } from "../../src/ipc";
 import { EventArgs, EventEmitter } from "../../src/events";
-import { IContainerOptions } from "../../src/i-container-options";
 
 class MockContainer extends ContainerBase {
     protected closeAllWindows(excludeSelf?: boolean): Promise<void> {
@@ -32,7 +31,7 @@ class MockContainer extends ContainerBase {
         throw new Error("Method not implemented.");
     }
 
-    public getOptions(): Promise<IContainerOptions> {
+    public getOptions(): Promise<any> {
         throw new Error("Method not implemented.");
     }
 


### PR DESCRIPTION
- Replace use of defined interface for type any to allow for support of any option across any container instead of restricting.
- Fix Electron implementation since LoginItemSettings is at the app level not electron
 
