### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,7 +1,6 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# This workflow will do a clean install of node dependencies, build the source code and run tests
 
-name: Continuous Integration
+name: CI
 
 on:
   push:
@@ -14,17 +13,15 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [12, 14]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+    env:
+      NODE_VERSION: '14'
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v2
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ env.NODE_VERSION }}
     - run: npm ci
     - run: npm run bootstrap
     - run: npm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+# This workflow will do a clean install of node dependencies, build the source code, publish to npm, and deploy latest docs to GitHub pages
+
+name: Release
+
+on:
+  release:
+    types: [ published ]
+    branches: [ main ]
+  workflow_dispatch:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      NODE_VERSION: '14'
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    
+    - name: Use Node.js ${{ env.NODE_VERSION }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+    - run: npm ci
+    - run: npm run bootstrap
+    - run: npm run build
+    - run: npm run docs
+
+    - name: Publish
+      if: success()
+      run: ./deploy.sh
+      with:
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: GitHub Pages
+      if: success()
+      uses: crazy-max/ghaction-github-pages@v2
+      with:
+        commit_message: Deploy morganstanley/desktopJS
+        build_dir: docs/
+        jekyll: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![desktopJS](https://raw.githubusercontent.com/wiki/MorganStanley/desktopJS/images/logo.png)
 ==========
 [![npm version](https://badge.fury.io/js/%40morgan-stanley%2Fdesktopjs.svg)](https://www.npmjs.com/package/@morgan-stanley/desktopjs)
-![Build Status](https://github.com/MorganStanley/desktopJS/actions/workflows/continuous-integration.yml/badge.svg?event=push)
+[![Build Status](https://github.com/MorganStanley/desktopJS/actions/workflows/continuous-integration.yml/badge.svg?event=push)](https://github.com/MorganStanley/desktopJS/actions/workflows/continuous-integration.yml)
 [![codecov](https://codecov.io/gh/MorganStanley/desktopJS/branch/main/graph/badge.svg)](https://codecov.io/gh/MorganStanley/desktopJS)
 
 desktopJS is a common API across multiple HTML5 containers. By programming to a


### PR DESCRIPTION
* Rename workflow name from "Continuous Integration" to "CI"
* Remove matrix build from ci as it is unnecessary.  This project doesn't target Node.js so version compatibility isn't critical.,
* Add release workflow for npm and docs.  Enable on release tag and manual.
* Add link to action from readme badge