### PR TITLE
Fixing typo in log warning message

### DIFF
--- a/packages/desktopjs/src/Default/default.ts
+++ b/packages/desktopjs/src/Default/default.ts
@@ -322,7 +322,7 @@ export namespace Default {
                 window[DefaultContainer.windowNamePropertyKey] = newOptions.name;
             } catch (e) {
                 windowReachable = false;
-                this.log("warn",`Error proprogating properties to new window, '${e.message}'`);
+                this.log("warn",`Error propagating properties to new window, '${e.message}'`);
             }
 
             const newWindow = this.wrapWindow(window);


### PR DESCRIPTION
Fixing a typo in default.ts log message: 'proprogating' -> 'propagating'