### PR TITLE
Add package-lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 docs/
 .DS_Store
 lerna-debug.log
+package-lock.json


### PR DESCRIPTION
With the removal of package-lock from the repo we need to also prevent it from being added accidentally.