### PR TITLE
Remove deprecated apis not available in OpenFin v22

### DIFF
--- a/examples/web/assets/js/app.js
+++ b/examples/web/assets/js/app.js
@@ -92,6 +92,13 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
 		// Enable popovers
 		$('[data-toggle="popover"]').popover();
+
+		if (!isOpenFin() && container.getCurrentWindow().id === "desktopJS") {
+			snapAssist = new desktopJS.SnapAssistWindowManager(container,
+				{
+					windowStateTracking: desktopJS.WindowStateTracking.Main | desktopJS.WindowStateTracking.Group
+				});
+		}
 	});
 });
 

--- a/examples/web/assets/js/app.js
+++ b/examples/web/assets/js/app.js
@@ -70,6 +70,8 @@ document.addEventListener("DOMContentLoaded", function (event) {
 		$("#button-joingroup").prop("disabled", !container.getCurrentWindow().allowGrouping);
 		$("#button-leavegroup").prop("disabled", !container.getCurrentWindow().allowGrouping);
 
+		$("#button-notification").prop("disabled", isOpenFin());
+
 		container.addListener("window-created", (e) => container.log("info", "Window created: " + e.window + ", " + e.windowId + ", " + e.windowName));
 		container.addListener("layout-loaded", (e) => container.log("info", "Layout loaded"));
 		container.addListener("layout-saved", (e) => container.log("info", "Layout saved"));
@@ -90,13 +92,6 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
 		// Enable popovers
 		$('[data-toggle="popover"]').popover();
-
-		if (container.getCurrentWindow().id === "desktopJS") {
-			snapAssist = new desktopJS.SnapAssistWindowManager(container,
-				{
-					windowStateTracking: desktopJS.WindowStateTracking.Main | desktopJS.WindowStateTracking.Group
-				});
-		}
 	});
 });
 
@@ -222,4 +217,9 @@ function getState() {
 /** Invoked by window layout loading to restore state specific to this window */
 function setState(state) {
 	this.container.log("info", state);
+}
+
+function isOpenFin() {
+	const pattern = /OpenFin/;
+	return pattern.test(window.navigator.userAgent);
 }

--- a/packages/desktopjs-openfin/src/openfin.ts
+++ b/packages/desktopjs-openfin/src/openfin.ts
@@ -18,7 +18,7 @@
 
 import {
     registerContainer, ContainerWindow, PersistedWindowLayout, Rectangle, Container, WebContainerBase,
-    ScreenManager, Display, Point, ObjectTransform, PropertyMap, NotificationOptions, ContainerNotification,
+    ScreenManager, Display, Point, ObjectTransform, PropertyMap, NotificationOptions,
     TrayIconDetails, MenuItem, Guid, MessageBus, MessageBusSubscription, MessageBusOptions, EventArgs,
     GlobalShortcutManager, WindowEventArgs
 } from "@morgan-stanley/desktopjs";
@@ -153,37 +153,19 @@ export class OpenFinContainerWindow extends ContainerWindow {
     }
 
     public get allowGrouping() {
-        return true;
+        return false;
     }
 
     public getGroup(): Promise<ContainerWindow[]> {
-        return new Promise<ContainerWindow[]>((resolve, reject) => {
-            this.innerWindow.getGroup(windows => {
-                resolve(windows.map(window => new OpenFinContainerWindow(window)));
-            }, reject);
-        });
+        return Promise.reject(new Error("Not supported"));
     }
 
     public joinGroup(target: ContainerWindow): Promise<void> {
-        if (!target || target.id === this.id) {
-            return Promise.resolve();
-        }
-
-        return new Promise<void>((resolve, reject) => {
-            this.innerWindow.joinGroup(target.innerWindow, () => {
-                ContainerWindow.emit("window-joinGroup", { name: "window-joinGroup", windowId: this.id, targetWindowId: target.id } );
-                resolve();
-            }, reject);
-        });
+        return Promise.reject(new Error("Not supported"));
     }
 
     public leaveGroup(): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            this.innerWindow.leaveGroup(() => {
-                ContainerWindow.emit("window-leaveGroup", { name: "window-leaveGroup", windowId: this.id } );
-                resolve();
-            }, reject);
-        });
+        return Promise.reject(new Error("Not supported"));
     }
 
     public bringToFront(): Promise<void> {
@@ -332,8 +314,6 @@ export class OpenFinContainer extends WebContainerBase {
     private static readonly trayIconMenuLeftOffset: number = 4;
     private static readonly trayIconMenuTopOffset: number = 23;
 
-    private static readonly notificationGuid: string = "A21B62E0-16B1-4B10-8BE3-BBB6B489D862";
-
     /**
      * Gets or sets whether to replace the native web Notification API with OpenFin notifications.
      * @type {boolean}
@@ -352,12 +332,6 @@ export class OpenFinContainer extends WebContainerBase {
     };
 
     public windowOptionsMap: PropertyMap = OpenFinContainer.windowOptionsMap;
-
-    public static readonly notificationOptionsMap: PropertyMap = {
-        body: { target: "message" }
-    };
-
-    public notificationOptionsMap: PropertyMap = OpenFinContainer.notificationOptionsMap;
 
     public static menuHtml =
         `<html>
@@ -478,21 +452,13 @@ export class OpenFinContainer extends WebContainerBase {
 
     protected registerNotificationsApi() {
         if (typeof this.globalWindow !== "undefined" && this.globalWindow) {
-            // Define owningContainer for closure to inner class
-            // eslint-disable-next-line @typescript-eslint/no-this-alias
-            const owningContainer: OpenFinContainer = this;
-
-            this.globalWindow["Notification"] = class OpenFinNotification extends ContainerNotification {
+            this.globalWindow["Notification"] = class OpenFinNotification {
                 constructor(title: string, options?: NotificationOptions) {
-                    super(title, options);
+                    throw new Error("Not supported");
+                }
 
-                    options["notification"] = this;
-
-                    // Forward OpenFin notification events back to Notification API
-                    options["onClick"] = (event) => { if (this.onclick) { this.onclick(event); } };
-                    options["onError"] = (event) => { if (this.onerror) { this.onerror(event); } };
-
-                    owningContainer.showNotification(this.title, this.options);
+                static async requestPermission(callback?: NotificationPermissionCallback): Promise<string> { 
+                    throw new Error("Not supported");
                 }
             };
         }
@@ -573,7 +539,7 @@ export class OpenFinContainer extends WebContainerBase {
     }
 
     public showNotification(title: string, options?: NotificationOptions) {
-        const msg = new this.desktop.Notification(ObjectTransform.transformProperties(options, this.notificationOptionsMap));
+        throw new Error("Not supported");
     }
 
     protected getMenuHtml() {
@@ -714,7 +680,7 @@ export class OpenFinContainer extends WebContainerBase {
             const mainWindow = this.getMainWindow();
             const promises: Promise<void>[] = [];
 
-            windows.filter(window => window.name !== "queueCounter" && !window.name.startsWith(OpenFinContainer.notificationGuid))
+            windows.filter(window => window.name !== "queueCounter")
                 .forEach(djsWindow => {
                     // eslint-disable-next-line no-async-promise-executor
                     promises.push(new Promise<void>(async (innerResolve, innerReject) => {
@@ -728,7 +694,6 @@ export class OpenFinContainer extends WebContainerBase {
                                     innerResolve();
                                 } else {
                                     delete (<any>options).show; // show is an undocumented option that interferes with the createWindow mapping of show -> autoShow
-                                    window.getGroup(group => {
                                         layout.windows.push(
                                             {
                                                 name: window.name,
@@ -737,11 +702,9 @@ export class OpenFinContainer extends WebContainerBase {
                                                 main: (mainWindow && (mainWindow.name === window.name)),
                                                 options: options,
                                                 state: state,
-                                                bounds: { x: bounds.left, y: bounds.top, width: bounds.width, height: bounds.height },
-                                                group: group.map(win => win.name)
+                                                bounds: { x: bounds.left, y: bounds.top, width: bounds.width, height: bounds.height }
                                             });
                                         innerResolve();
-                                    }, innerReject);
                                 }
                             }, innerReject);
                         }, innerReject);

--- a/packages/desktopjs-openfin/src/openfin.ts
+++ b/packages/desktopjs-openfin/src/openfin.ts
@@ -152,22 +152,6 @@ export class OpenFinContainerWindow extends ContainerWindow {
         });
     }
 
-    public get allowGrouping() {
-        return false;
-    }
-
-    public getGroup(): Promise<ContainerWindow[]> {
-        return Promise.reject(new Error("Not supported"));
-    }
-
-    public joinGroup(target: ContainerWindow): Promise<void> {
-        return Promise.reject(new Error("Not supported"));
-    }
-
-    public leaveGroup(): Promise<void> {
-        return Promise.reject(new Error("Not supported"));
-    }
-
     public bringToFront(): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             this.innerWindow.bringToFront(resolve, reject);
@@ -536,10 +520,6 @@ export class OpenFinContainer extends WebContainerBase {
                 resolve(this.wrapWindow(ofWin));
             }, reject);
         });
-    }
-
-    public showNotification(title: string, options?: NotificationOptions) {
-        throw new Error("Not supported");
     }
 
     protected getMenuHtml() {

--- a/packages/desktopjs-openfin/tests/openfin.spec.ts
+++ b/packages/desktopjs-openfin/tests/openfin.spec.ts
@@ -424,24 +424,6 @@ describe("OpenFinContainerWindow", () => {
         });
     });
 
-    describe("window grouping", () => {
-        it("allowGrouping is true", () => {
-            expect(win.allowGrouping).toEqual(false);
-        });
-
-        it ("getGroup not supported", async () => {
-            await expectAsync(win.getGroup()).toBeRejectedWithError("Not supported");
-        });
-
-        it ("joinGroup not supported", async () => {
-            await expectAsync(win.joinGroup(null)).toBeRejectedWithError("Not supported");
-        });
-
-        it ("leaveGroup not supported", async () => {
-            await expectAsync(win.leaveGroup()).toBeRejectedWithError("Not supported");
-        });
-    });
-
     it("bringToFront invokes underlying bringToFront", async () => {
         spyOn(innerWin, "bringToFront").and.callThrough();
         await win.bringToFront();
@@ -712,10 +694,6 @@ describe("OpenFinContainer", () => {
     });
 
     describe("notifications", () => {
-        it("showNotification not supported", () => {
-            expect(() => container.showNotification("title", { body: "Test message", url: "notification.html" })).toThrowError("Not supported");
-        });
-
         it("requestPermission not supported", async () => {
             await expectAsync(globalWindow["Notification"].requestPermission()).toBeRejectedWithError("Not supported");
         });


### PR DESCRIPTION
OpenFin v22 has deprecated a number of APIs that are used in this project. Removing references to grouping and notification APIs that are no longer available.