### PR TITLE
ci(release): remove npm token env variable, use trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      NODE_VERSION: '20'
+      NODE_VERSION: '22'
 
     steps:
     - name: Checkout
@@ -34,9 +34,7 @@ jobs:
 
     - name: Publish
       if: success()
-      run: ./deploy.sh
-      env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: npm run deploy
 
     - name: GitHub Pages
       if: success()

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-npm run deploy


### PR DESCRIPTION
Replace explicit NPM_TOKEN environment variable with OIDC-based trusted publishing for enhanced security and simplified token management.