### PR TITLE
ci: update Node.js version to 24 and use npm ci in workflows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      NODE_VERSION: '20'
+      NODE_VERSION: '24'
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - run: npm i
+    - run: npm ci
     - run: npm run lint
     - run: npm run build
     - run: npm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      NODE_VERSION: '22'
+      NODE_VERSION: '24'
 
     steps:
     - name: Checkout
@@ -28,7 +28,7 @@ jobs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - run: npm i
+    - run: npm ci
     - run: npm run build
     - run: npm run docs
 


### PR DESCRIPTION
- Bump NODE_VERSION to 24 in CI and release GitHub Actions workflows
- Replace 'npm i' with 'npm ci' for consistent dependency installation