### PR TITLE
Fix sourcemap paths

### DIFF
--- a/packages/desktopjs-electron/vite.config.ts
+++ b/packages/desktopjs-electron/vite.config.ts
@@ -36,6 +36,9 @@ const sharedConfig = {
         globals: {
           electron: 'electron',
           '@morgan-stanley/desktopjs': 'desktopJS'
+        },
+        sourcemapPathTransform: (relativeSourcePath: string) => {
+          return relativeSourcePath.replace(/^\.\.[\\/]src[\\/]/, './');
         }
       }
     }

--- a/packages/desktopjs-openfin/vite.config.ts
+++ b/packages/desktopjs-openfin/vite.config.ts
@@ -35,6 +35,9 @@ const sharedConfig = {
       output: {
         globals: {
           '@morgan-stanley/desktopjs': 'desktopJS'
+        },
+        sourcemapPathTransform: (relativeSourcePath: string) => {
+          return relativeSourcePath.replace(/^\.\.[\\/]src[\\/]/, './');
         }
       }
     }

--- a/packages/desktopjs/vite.config.ts
+++ b/packages/desktopjs/vite.config.ts
@@ -39,7 +39,10 @@ const sharedConfig = {
     },
     rollupOptions: {
       output: {
-        globals: {}
+        globals: {},
+        sourcemapPathTransform: (relativeSourcePath: string) => {
+          return relativeSourcePath.replace(/^(\.\.[\\/])+src[\\/]/, './');
+        }
       }
     }
   }


### PR DESCRIPTION
This fixes the sourcemap paths errors when you try to consume this package in a webpack built project:

> WARNING in ../../node_modules/@morgan-stanley/desktopjs/dist/desktop.js
Module Warning (from ../../node_modules/@nx/webpack/node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/basePath/projectName/node_modules/@morgan-stanley/desktopjs/src/screen.ts' file: Error: ENOENT: no such file or directory, open '/basePath/projectName/node_modules/@morgan-stanley/desktopjs/src/screen.ts'

I don't particularly like the fix as it's complicated and hard to understand. It is very possible that there is a simpler fix but I don't understand rollup so as this fix worked I am submitting it as a potential fix. Feel free to reject it!

This was built and tested locally in my webpack project and the sourcemap errors went away.