### PR TITLE
Harden layout persistence against poisoned localStorage

### DIFF
--- a/packages/desktopjs/src/container.ts
+++ b/packages/desktopjs/src/container.ts
@@ -191,16 +191,56 @@ export abstract class ContainerBase extends Container {
         throw new TypeError("Tray icons are not supported by this container.");
     }
 
-    public storage: Storage = (typeof window !== "undefined" && window)
-        ? window.localStorage
-        : undefined;
+    public storage: Storage;
+
+    protected constructor(storage?: Storage) {
+        super();
+        this.storage = storage ?? ((typeof window !== "undefined" && window) ? window.localStorage : undefined);
+    }
+
+    // Keys that could re-target an object's prototype if later merged with Object.assign
+    private static readonly unsafeJsonKeys: ReadonlySet<string> = new Set(["__proto__", "constructor", "prototype"]);
+
+    /** Parses persisted layout JSON, stripping keys that could be used for prototype pollution
+     * and tolerating missing/corrupt storage instead of throwing.
+     */
+    private parseLayoutsFromStorage(): any {
+        const raw = this.storage.getItem(ContainerBase.layoutsPropertyKey);
+        if (!raw) {
+            return undefined;
+        }
+
+        try {
+            return JSON.parse(raw, (key, value) => ContainerBase.unsafeJsonKeys.has(key) ? undefined : value);
+        } catch (e) {
+            this.log("warn", `Unable to parse persisted layouts, ignoring: ${e}`);
+            return undefined;
+        }
+    }
+
+    /** Restricts a persisted layout window url to the http(s)/relative schemes createWindow expects,
+     * rejecting schemes (eg. javascript:, data:) that a poisoned layout could use to run script on load.
+     */
+    protected sanitizeUrl(url: string): string {
+        if (!url) {
+            return url;
+        }
+
+        const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(url);
+        if (schemeMatch && !["http", "https"].includes(schemeMatch[1].toLowerCase())) {
+            this.log("warn", `Blocked layout window with disallowed url scheme '${schemeMatch[1]}'`);
+            return undefined;
+        }
+
+        return url;
+    }
 
     protected getLayoutFromStorage(name: string): PersistedWindowLayout {
-        return JSON.parse(this.storage.getItem(ContainerBase.layoutsPropertyKey))[name];
+        return this.parseLayoutsFromStorage()?.[name];
     }
 
     protected saveLayoutToStorage(name: string, layout: PersistedWindowLayout) {
-        const layouts: any = JSON.parse(this.storage.getItem(ContainerBase.layoutsPropertyKey)) || {};
+        const layouts: any = this.parseLayoutsFromStorage() || {};
 
         if (!layout.name) {
             layout.name = name;
@@ -214,7 +254,7 @@ export abstract class ContainerBase extends Container {
     }
 
     protected deleteLayoutFromStorage(name: string) {
-        const layouts: any = JSON.parse(this.storage.getItem(ContainerBase.layoutsPropertyKey)) || {};
+        const layouts: any = this.parseLayoutsFromStorage() || {};
         const layout = layouts[name];
 
         if (layout) {
@@ -241,7 +281,11 @@ export abstract class ContainerBase extends Container {
                     this.getMainWindow().setBounds(window.bounds);
                     promises.push(Promise.resolve(this.getMainWindow()));
                 } else {
-                    promises.push(this.createWindow(window.url, options));
+                    const url = this.sanitizeUrl(window.url);
+                    if (window.url && !url) {
+                        continue; // url was rejected as unsafe; do not create this window
+                    }
+                    promises.push(this.createWindow(url, options));
                 }
             }
             
@@ -274,7 +318,7 @@ export abstract class ContainerBase extends Container {
             groupMap.forEach((targets, window) => {
                 targets.forEach(target => {
                     this.getWindowByName(layoutToLoad.windows.find(win => win.id === target).name).then(targetWin => {
-                        targetWin.joinGroup(window);
+                        targetWin?.joinGroup(window);
                     });
                 });
             });
@@ -301,9 +345,8 @@ export abstract class ContainerBase extends Container {
     }
 
     public async getLayouts(): Promise<PersistedWindowLayout[]> {
-        const rawLayouts = this.storage.getItem(ContainerBase.layoutsPropertyKey);
-        if (rawLayouts) {
-            const layouts = JSON.parse(rawLayouts);
+        const layouts = this.parseLayoutsFromStorage();
+        if (layouts) {
             return Object.getOwnPropertyNames(layouts).map(key => layouts[key]);
         }
     }

--- a/packages/desktopjs/tests/unit/container.spec.ts
+++ b/packages/desktopjs/tests/unit/container.spec.ts
@@ -308,6 +308,50 @@ describe("container", () => {
                 expect(layout.name).toEqual(undefined);
             });
 
+            it ("loadLayout rejects javascript: url and does not create that window", async () => {
+                const layoutToLoad: PersistedWindowLayout = new PersistedWindowLayout("Test");
+                layoutToLoad.windows.push({ name: "1", id: "1", url: "javascript:alert(document.domain)", bounds: {} } as any);
+
+                const layout = await container.loadLayout(layoutToLoad);
+                expect(container.createWindow).not.toHaveBeenCalled();
+                expect(layout).toBeDefined();
+            });
+
+            it ("loadLayout rejects data: url and does not create that window", async () => {
+                const layoutToLoad: PersistedWindowLayout = new PersistedWindowLayout("Test");
+                layoutToLoad.windows.push({ name: "1", id: "1", url: "data:text/html,<script>alert(1)</script>", bounds: {} } as any);
+
+                const layout = await container.loadLayout(layoutToLoad);
+                expect(container.createWindow).not.toHaveBeenCalled();
+                expect(layout).toBeDefined();
+            });
+
+            it ("loadLayout still creates windows with http(s) and relative urls", async () => {
+                const layoutToLoad: PersistedWindowLayout = new PersistedWindowLayout("Test");
+                layoutToLoad.windows.push({ name: "1", id: "1", url: "https://example.com", bounds: {} } as any);
+                layoutToLoad.windows.push({ name: "2", id: "2", url: "relative/path", bounds: {} } as any);
+
+                await container.loadLayout(layoutToLoad);
+                expect(container.createWindow).toHaveBeenCalledTimes(2);
+                expect(container.createWindow).toHaveBeenCalledWith("https://example.com", { name: "1" });
+                expect(container.createWindow).toHaveBeenCalledWith("relative/path", { name: "2" });
+            });
+
+            it ("loadLayout tolerates malformed JSON in storage instead of throwing", async () => {
+                jest.spyOn(container.storage, "getItem").mockReturnValue("{not valid json");
+                await expect(container.loadLayout("Test")).rejects.toThrow("Layout does not exist or is invalid");
+            });
+
+            it ("loadLayout strips __proto__ keys from persisted layout JSON", async () => {
+                const poisoned = `{"Test": {"name": "Test", "windows": [{"name": "1", "id": "1", "url": "url", "bounds": {}, "options": {"__proto__": {"polluted": true}}}]}}`;
+                jest.spyOn(container.storage, "getItem").mockReturnValue(poisoned);
+
+                await container.loadLayout("Test");
+
+                expect(container.createWindow).toHaveBeenCalledWith("url", expect.objectContaining({ name: "1" }));
+                expect(({} as any).polluted).toBeUndefined();
+            });
+
             it("saveLayoutToStorage", () => {
                 const layout: PersistedWindowLayout = new PersistedWindowLayout();
                 (<any>container).saveLayoutToStorage("Test", layout);


### PR DESCRIPTION
## Summary
`loadLayout` replays a layout JSON blob from `localStorage` on every future session, so a one-shot XSS that plants a malicious `desktopJS-layouts` entry keeps firing on reload. This closes that off in `ContainerBase`:
