### PR TITLE
Harden static-event forwarding and DefaultMessageBus

### DIFF
--- a/packages/desktopjs/src/Default/default.ts
+++ b/packages/desktopjs/src/Default/default.ts
@@ -173,12 +173,10 @@ export namespace Default {
         }
 
         async publish<T>(topic: string, message: T, options?: MessageBusOptions) {
-            // Get list of windows from global (set by opener on creation) or fallback to opener global in case
-            // there is a race condition of getting here before the opener set the global for us
-            const windows: Window[] = (this.container.globalWindow)
-                ? this.container.globalWindow[DefaultContainer.windowsPropertyKey]
-                || this.container.globalWindow.opener?.[DefaultContainer.windowsPropertyKey]
-                : [];
+            // Only use the windows list the desktopJS runtime tracks directly on this window.
+            // Do not fall back to window.opener: for a window not created via createWindow,
+            // opener may be an untrusted page that can plant its own windows list there.
+            const windows: Window[] = this.container.globalWindow?.[DefaultContainer.windowsPropertyKey];
 
             if (windows) {
                 for (const key in windows) {
@@ -188,7 +186,12 @@ export namespace Default {
                         continue;
                     }
 
-                    const targetOrigin = options?.targetOrigin || this.container.globalWindow.location.origin;
+                    // Never broadcast to a wildcard origin; a caller-supplied "*" would let any
+                    // origin the target window later navigates to read the published message.
+                    const requestedOrigin = options?.targetOrigin;
+                    const targetOrigin = (requestedOrigin && requestedOrigin !== "*")
+                        ? requestedOrigin
+                        : this.container.globalWindow.location.origin;
                     win.postMessage({ source: DefaultMessageBus.messageSource, topic, message }, targetOrigin);
                 }
             }

--- a/packages/desktopjs/src/container.ts
+++ b/packages/desktopjs/src/container.ts
@@ -168,10 +168,14 @@ export abstract class Container extends EventEmitter implements ContainerWindowM
         EventEmitter.emit(Container.staticEventScopePrefix + eventName, eventArgs, Container.ipc);
     }
 
-    public static listeners(eventName: string): ((event: EventArgs) => void)[] { 
+    public static listeners(eventName: string): ((event: EventArgs) => void)[] {
         return EventEmitter.listeners(Container.staticEventScopePrefix + eventName);
     }
 }
+
+// Registers the container-level event names permitted to travel over the shared MessageBus so
+// EventEmitter can reject forged/unknown static events (see ContainerEventType).
+EventEmitter.registerStaticEventNames("container-", ["window-created", "layout-loaded", "layout-saved", "layout-deleted"]);
 
 /**
  * Represents a common Container to be used as a base for any custom Container implementation.

--- a/packages/desktopjs/src/events.ts
+++ b/packages/desktopjs/src/events.ts
@@ -43,6 +43,44 @@ export class EventEmitter {
 
     private static readonly staticEventName: string = "desktopJS.static-event";
 
+    // Static event names a known scope (eg. "container-", "containerwindow-") is allowed to
+    // broadcast/receive over the shared MessageBus. Populated by Container/ContainerWindow at
+    // module load. Used to reject forged static events carrying names no scope actually emits.
+    private static readonly allowedStaticEventNames: Set<string> = new Set();
+
+    // Keys that could re-target an object's prototype if a listener later merges eventArgs
+    // into another object (eg. via Object.assign).
+    private static readonly unsafeKeys: ReadonlySet<string> = new Set(["__proto__", "constructor", "prototype"]);
+
+    /**
+     * Registers the event names a static event scope is allowed to broadcast/receive.
+     * @param {string} scopePrefix The static event scope prefix (eg. "container-").
+     * @param {string[]} eventNames The event names valid for that scope.
+     */
+    public static registerStaticEventNames(scopePrefix: string, eventNames: string[]): void {
+        for (const name of eventNames) {
+            EventEmitter.allowedStaticEventNames.add(scopePrefix + name);
+        }
+    }
+
+    /** Recursively strips prototype-pollution keys from an inbound (untrusted) event payload. */
+    private static sanitizeEventArgs(value: any, seen: Set<any> = new Set()): any {
+        if (!value || typeof value !== "object" || seen.has(value)) {
+            return value;
+        }
+
+        seen.add(value);
+        for (const key of Object.getOwnPropertyNames(value)) {
+            if (EventEmitter.unsafeKeys.has(key)) {
+                delete value[key];
+                continue;
+            }
+            value[key] = EventEmitter.sanitizeEventArgs(value[key], seen);
+        }
+
+        return value;
+    }
+
     /**
      * Registers an event listener on the specified event.
      * @param {string} eventName The type of the event.
@@ -130,7 +168,15 @@ export class EventEmitter {
     public static set ipc(value: MessageBus) {
         if (value) {
             value.subscribe(EventEmitter.staticEventName, (event: any, message: any) => {
-                EventEmitter.emit(message.eventName, message.eventArgs);
+                const eventName = message?.eventName;
+
+                // Reject forged/unknown static events instead of trusting eventName/eventArgs
+                // from any sender able to publish on the shared MessageBus.
+                if (typeof eventName !== "string" || !EventEmitter.allowedStaticEventNames.has(eventName)) {
+                    return;
+                }
+
+                EventEmitter.emit(eventName, EventEmitter.sanitizeEventArgs(message.eventArgs));
             });
         }
     }

--- a/packages/desktopjs/src/window.ts
+++ b/packages/desktopjs/src/window.ts
@@ -237,10 +237,17 @@ export abstract class ContainerWindow extends EventEmitter {
         EventEmitter.emit(ContainerWindow.staticEventScopePrefix + eventName, eventArgs, Container.ipc);
     }
 
-    public static listeners(eventName: string): ((event: EventArgs) => void)[] { 
+    public static listeners(eventName: string): ((event: EventArgs) => void)[] {
         return EventEmitter.listeners(ContainerWindow.staticEventScopePrefix + eventName);
     }
 }
+
+// Registers the window-level event names permitted to travel over the shared MessageBus so
+// EventEmitter can reject forged/unknown static events (see WindowEventType).
+EventEmitter.registerStaticEventNames("containerwindow-", [
+    "window-created", "window-joinGroup", "window-leaveGroup", "move", "resize", "close", "closed",
+    "focus", "blur", "maximize", "minimize", "restore", "beforeunload", "state-changed"
+]);
 
 /** Represents window management capability */
 export interface ContainerWindowManager {

--- a/packages/desktopjs/tests/unit/Default/default.spec.ts
+++ b/packages/desktopjs/tests/unit/Default/default.spec.ts
@@ -618,6 +618,23 @@ describe("DefaultMessageBus", () => {
         await bus.publish("topic", message, { name: "target" });
         expect(mockWindow.postMessage).not.toHaveBeenCalled();
     });
+
+    it("publish ignores an opener-provided windows list instead of the container's own", async () => {
+        // Simulate a window opened by an untrusted page that planted its own windows list on opener
+        const evilWindow: any = { postMessage: jest.fn(), [Default.DefaultContainer.windowNamePropertyKey]: "evil" };
+        delete mockWindow[Default.DefaultContainer.windowsPropertyKey];
+        mockWindow.opener = { [Default.DefaultContainer.windowsPropertyKey]: { evil: evilWindow } };
+
+        await bus.publish("topic", { data: "data" });
+
+        expect(evilWindow.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("publish never honors a wildcard targetOrigin", async () => {
+        jest.spyOn(mockWindow, "postMessage").mockImplementation(() => {});
+        await bus.publish("topic", { data: "data" }, { targetOrigin: "*" });
+        expect(mockWindow.postMessage).toHaveBeenCalledWith(expect.anything(), "origin");
+    });
 });
 
 describe("DefaultDisplayManager", () => {

--- a/packages/desktopjs/tests/unit/events.spec.ts
+++ b/packages/desktopjs/tests/unit/events.spec.ts
@@ -13,8 +13,22 @@
  */
 
 import { EventEmitter, EventArgs } from "../../src/events";
+import { MessageBus, MessageBusSubscription, MessageBusOptions } from "../../src/ipc";
 
 class TestEmitter extends EventEmitter {
+}
+
+class CapturingMessageBus implements MessageBus {
+    public capturedListener: (event: any, message: any) => void;
+
+    async subscribe<T>(topic: string, listener: (event: any, message: T) => void, options?: MessageBusOptions): Promise<MessageBusSubscription> {
+        this.capturedListener = listener;
+        return new MessageBusSubscription(topic, listener, options);
+    }
+
+    async unsubscribe(): Promise<void> { }
+
+    async publish(): Promise<void> { }
 }
 
 describe("EventArgs", () => {
@@ -91,5 +105,55 @@ describe("EventEmitter", () => {
         args.returnValue = "Foo";
         emitter.postProcessArgs(args)
         expect(innerEvent.returnValue).toEqual("Foo");
-    }); 
+    });
+});
+
+describe("EventEmitter static ipc forwarding", () => {
+    let bus: CapturingMessageBus;
+
+    beforeEach(async () => {
+        bus = new CapturingMessageBus();
+        (<any>EventEmitter).staticEventListeners = new Map();
+        EventEmitter.registerStaticEventNames("test-scope-", ["known-event"]);
+        EventEmitter.ipc = bus;
+        await Promise.resolve();
+    });
+
+    it ("forwards a known, allowlisted static event", (done) => {
+        EventEmitter.addListener("test-scope-known-event", (event: any) => {
+            expect(event.value).toEqual("ok");
+            done();
+        });
+
+        bus.capturedListener({}, { eventName: "test-scope-known-event", eventArgs: { value: "ok" } });
+    });
+
+    it ("drops a forged static event with an unregistered name", () => {
+        const listener = jest.fn();
+        EventEmitter.addListener("container-layout-saved-forged", listener);
+
+        bus.capturedListener({}, { eventName: "container-layout-saved-forged", eventArgs: { evil: true } });
+
+        expect(listener).not.toHaveBeenCalled();
+    });
+
+    it ("drops a static event with a non-string eventName", () => {
+        const listener = jest.fn();
+        EventEmitter.addListener("test-scope-known-event", listener);
+
+        bus.capturedListener({}, { eventName: { toString: () => "test-scope-known-event" }, eventArgs: {} });
+
+        expect(listener).not.toHaveBeenCalled();
+    });
+
+    it ("strips __proto__/constructor/prototype keys from inbound eventArgs", (done) => {
+        EventEmitter.addListener("test-scope-known-event", (event: any) => {
+            expect(Object.prototype.hasOwnProperty.call(event, "__proto__")).toEqual(false);
+            expect(({} as any).polluted).toBeUndefined();
+            done();
+        });
+
+        const poisoned = JSON.parse('{"safe": "value", "__proto__": {"polluted": true}}');
+        bus.capturedListener({}, { eventName: "test-scope-known-event", eventArgs: poisoned });
+    });
 });


### PR DESCRIPTION
## Summary
- `EventEmitter`'s `ipc` setter re-broadcast any inbound `message.eventName`/`eventArgs` from the shared MessageBus as a local static event, so anyone able to publish on that bus could forge events like `container-layout-saved` with attacker-controlled args (CHAIN-02's entry point). `Container`/`ContainerWindow` now register the static event names their scope actually emits via `EventEmitter.registerStaticEventNames`, and the `ipc` setter drops anything outside that allowlist and strips `__proto__`/`constructor`/`prototype` keys from what it does forward.
- `DefaultMessageBus.publish` fell back to reading the windows list off `window.opener` when the current window hadn't yet had its own list set (trusting whatever the opener planted there), and forwarded a caller-supplied `targetOrigin` verbatim (so `"*"` would broadcast to whatever origin the target window later navigates to). `publish` now only uses the windows list the runtime tracks directly on the window, and never honors a wildcard target origin.
