### PR TITLE
Harden OpenFin tray menu HTML and message bus sender identity

### DIFF
--- a/packages/desktopjs-openfin/src/openfin.ts
+++ b/packages/desktopjs-openfin/src/openfin.ts
@@ -245,7 +245,10 @@ export class OpenFinMessageBus implements MessageBus {
     public subscribe<T>(topic: string, listener: (event: any, message: T) => void, options?: MessageBusOptions): Promise<MessageBusSubscription> {
         return new Promise<MessageBusSubscription>((resolve, reject) => {
             const subscription: MessageBusSubscription = new MessageBusSubscription(topic, (message: any, uuid: string, name: string) => {
-                listener( /* Event */ { topic: topic }, message);
+                // Forward the OpenFin-supplied sender identity so callers can authorize senders
+                // instead of accepting messages from any uuid/name (the default subscribe below
+                // uses "*" for senderUuid unless the caller opted into a specific one).
+                listener( /* Event */ { topic: topic, uuid: uuid, name: name }, message);
             }, options);
 
             this.bus.subscribe(options && options.uuid || "*",      // senderUuid
@@ -546,13 +549,37 @@ export class OpenFinContainer extends WebContainerBase {
         return OpenFinContainer.menuHtml;
     }
 
+    // Escapes text/attribute values interpolated into menu HTML built from MenuItem fields,
+    // which may originate from untrusted content (eg. a remote page's title or a saved item name).
+    private escapeHtml(value: string): string {
+        return String(value ?? "").replace(/[&<>"']/g, char => {
+            switch (char) {
+                case "&": return "&amp;";
+                case "<": return "&lt;";
+                case ">": return "&gt;";
+                case "\"": return "&quot;";
+                case "'": return "&#39;";
+                default: return char;
+            }
+        });
+    }
+
     protected getMenuItemHtml(item: MenuItem) {
         const imgHtml: string = (item.icon)
-            ? `<span><img align="absmiddle" class="context-menu-image" src="${this.ensureAbsoluteUrl(item.icon)}" /></span>`
+            ? `<span><img align="absmiddle" class="context-menu-image" src="${this.escapeHtml(this.ensureAbsoluteUrl(item.icon))}" /></span>`
             : "<span>&nbsp;</span>";
 
-        return `<li class="context-menu-item" onclick="fin.desktop.InterApplicationBus.send('${(<any>this.desktop.Application.getCurrent()).uuid}`
-            + `', null, 'TrayIcon_ContextMenuClick_${this.uuid}', { id: '${item.id}' });this.close()">${imgHtml}${item.label}</li>`;
+        // Build the onclick handler's JS string arguments with JSON.stringify rather than raw
+        // interpolation so a MenuItem.id containing a quote can't break out of the literal and
+        // run arbitrary script. JSON.stringify always double-quotes, so the resulting JS
+        // expression is then HTML-attribute-escaped as a whole before going into onclick="...",
+        // otherwise those double quotes would themselves close the attribute early.
+        const appUuid = JSON.stringify((<any>this.desktop.Application.getCurrent()).uuid);
+        const contextMenuTopic = JSON.stringify(`TrayIcon_ContextMenuClick_${this.uuid}`);
+        const itemId = JSON.stringify(item.id);
+        const onclick = `fin.desktop.InterApplicationBus.send(${appUuid}, null, ${contextMenuTopic}, { id: ${itemId} });this.close()`;
+
+        return `<li class="context-menu-item" onclick="${this.escapeHtml(onclick)}">${imgHtml}${this.escapeHtml(item.label)}</li>`;
     }
 
     private showMenu(x: number, y: number, monitorInfo: any, menuItems: MenuItem[]) {

--- a/packages/desktopjs-openfin/tests/openfin.spec.ts
+++ b/packages/desktopjs-openfin/tests/openfin.spec.ts
@@ -1041,6 +1041,31 @@ describe("OpenFinContainer", () => {
             const menuItemHtml: string = (container as any).getMenuItemHtml(menuItem);
             expect(menuItemHtml).toContain(`<span>&nbsp;</span>Label`);
         });
+
+        it("getMenuItemHtml HTML-escapes a label containing markup", () => {
+            const menuItem: MenuItem = { id: "ID", label: "<script>alert(1)</script>" };
+            const menuItemHtml: string = (container as any).getMenuItemHtml(menuItem);
+            expect(menuItemHtml).not.toContain("<script>");
+            expect(menuItemHtml).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+        });
+
+        it("getMenuItemHtml HTML-escapes an icon url containing a quote", () => {
+            const menuItem: MenuItem = { id: "ID", label: "Label", icon: `Icon" onerror="alert(1)` };
+            const menuItemHtml: string = (container as any).getMenuItemHtml(menuItem);
+            expect(menuItemHtml).not.toContain(`Icon" onerror="alert(1)`);
+            expect(menuItemHtml).toContain("&quot;");
+        });
+
+        it("getMenuItemHtml never leaks a raw double quote from item.id/label that could break out of the onclick/class attributes", () => {
+            const menuItem: MenuItem = { id: `x"); alert(document.domain); ({id:"x`, label: `"><img src=x onerror=alert(1)>` };
+            const menuItemHtml: string = (container as any).getMenuItemHtml(menuItem);
+
+            // Every raw double quote in the output should belong to class="context-menu-item" and
+            // onclick="..." only; anything from item.id/label must come through HTML-escaped.
+            const quoteCount = (menuItemHtml.match(/"/g) || []).length;
+            expect(quoteCount).toEqual(4);
+            expect(menuItemHtml).not.toContain("<img src=x onerror=");
+        });
     });
 
     it("addTrayIcon invokes underlying setTrayIcon", () => {
@@ -2446,6 +2471,17 @@ describe("OpenFinMessageBus", () => {
     it("subscribe with options invokes underlying subscribe", async () => {
         await bus.subscribe("topic", callback, { uuid: "uuid", name: "name" });
         expect(mockBus.subscribe).toHaveBeenCalledWith("uuid", "name", "topic", expect.any(Function), expect.any(Function), expect.any(Function));
+    });
+
+    it("subscribe forwards sender uuid/name to the listener so callers can authorize senders", async () => {
+        const received: any[] = [];
+        await bus.subscribe("topic", (event: any, message: any) => received.push(event));
+
+        // Invoke the wrapped listener passed to the underlying bus, simulating an inbound message
+        const wrappedListener = mockBus.subscribe.mock.calls[0][3];
+        wrappedListener({ data: "payload" }, "sender-uuid", "sender-name");
+
+        expect(received).toEqual([{ topic: "topic", uuid: "sender-uuid", name: "sender-name" }]);
     });
 
     it("unsubscribe invokes underlying unsubscribe", async () => {


### PR DESCRIPTION
## Summary
-  `getMenuItemHtml` built the tray context menu's `<li>` markup by interpolating `MenuItem.label`/`.icon` directly into HTML with no escaping, and `MenuItem.id` directly into an inline `onclick` JS string with no escaping. A menu item sourced from untrusted content (eg. a remote page's title) could inject markup or break out of the `onclick` string to run arbitrary script when the tray menu renders. `label`/`icon` are now HTML-escaped, and the `onclick` handler's arguments are built with `JSON.stringify` and then HTML-attribute-escaped as a whole (JSON.stringify's own double quotes would otherwise collide with the `onclick="..."` attribute delimiter).
- `OpenFinMessageBus.subscribe` discarded the sender `uuid`/`name` that OpenFin's `InterApplicationBus.subscribe` callback provides, so listener code had no way to tell who sent a message and authorize accordingly (especially since the default `senderUuid` is `"*"`). `subscribe` now forwards `uuid`/`name` to the listener's event object.